### PR TITLE
v1.0.8

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -25,8 +25,12 @@ jobs:
         run: dart analyze --fatal-infos --fatal-warnings .
       - name: dependency_validator
         run: dart run dependency_validator
-      - name: Run tests
-        run: dart test
+      - name: Run tests (VM)
+        run: dart test --platform vm
+      - name: Run tests (exe)
+        run: dart test --compiler exe
+      - name: Run tests (Chrome)
+        run: dart test --platform chrome
       - name: dart doc
         run:  dart doc --dry-run
       - name: Generate coverage report

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 - New `BytesIO`:
   - Implementations: `BytesFileIO` and `BytesUint8ListIO`.
 - Added constructor `BytesBuffer.fromIO`.
+- `DataSerializerPlatformGeneric`:
+  - Fixed `_writeInt64` and `_readInt64` for JS/Browser platform.
+
+- Dart CI:
+  - Tests platforms: vm, exe, chrome. 
 
 - sdk: '>=2.18.4 <4.0.0'
 - collection: ^1.18.0

--- a/dart_test.yaml
+++ b/dart_test.yaml
@@ -1,13 +1,22 @@
 
 tags:
-  # Test number tests.
+  # Number tests.
   num:
     timeout: 30s
-  # Test bytes tests.
+  # Bytes tests.
   bytes:
     timeout: 30s
-  # Test number tests.
+  # IO memory tests.
+  mem:
+    timeout: 30s
+  # IO file tests.
+  file:
+    timeout: 30s
+  # Platform number tests.
   platform:
+    timeout: 30s
+  # Platform safe numbers tests.
+  safe_numbers:
     timeout: 30s
 
 timeout: 3x
@@ -29,5 +38,4 @@ define_platforms:
     settings:
       executable:
         linux: firefox-esr
-
 

--- a/lib/src/platform.dart
+++ b/lib/src/platform.dart
@@ -3,9 +3,13 @@ import 'dart:typed_data';
 import 'int_codec.dart';
 import 'platform_generic.dart' if (dart.library.io) 'platform_io.dart';
 
+/// `data_serializer` platform dependent functions.
+/// The implementation resolve special cases for each platform.
 abstract class DataSerializerPlatform {
+  /// Singleton instance of current [DataSerializerPlatform] implementation.
   static final DataSerializerPlatform instance = createPlatformInstance();
 
+  /// Returns [instance] singleton.
   factory DataSerializerPlatform() => instance;
 
   late final BigInt _maxSafeBigInt;
@@ -17,30 +21,46 @@ abstract class DataSerializerPlatform {
     _minSafeBigInt = BigInt.from(minSafeInt);
   }
 
+  /// The maximum safe `int` int the current platform.
   int get maxSafeInt;
 
+  /// The minimum safe `int` int the current platform.
   int get minSafeInt;
 
+  /// The maximum safe `int` int the current platform as [BigInt].
+  BigInt get maxSafeIntAsBigInt => BigInt.from(maxSafeInt);
+
+  /// The minimum safe `int` int the current platform as [BigInt].
+  BigInt get minSafeIntAsBigInt => BigInt.from(minSafeInt);
+
+  /// The maximum safe `int` int the current platform as [Uint8List].
   Uint8List get maxSafeIntBytes;
 
+  /// The minimum safe `int` int the current platform as [Uint8List].
   Uint8List get minSafeIntBytes;
 
+  /// The amount of bits of a safe integer.
   int get safeIntBits;
 
+  /// Returns `true` if the platform fully supports 64 bits integers.
   bool get supportsFullInt64;
 
+  /// Returns `true` if [n] is a safe `int`.
   bool isSafeInteger(int n);
 
+  /// Checks if [n] is a safe `int`. Throws [StateError] if is not a safe `int`.
   void checkSafeInteger(int n) {
     if (!isSafeInteger(n)) {
       throw StateError(_sageErrorMessage(n));
     }
   }
 
+  /// Returns `true` if [n] is a safe `int`.
   bool isSafeIntegerByBigInt(BigInt n) {
     return n <= _maxSafeBigInt && n >= _minSafeBigInt;
   }
 
+  /// Checks if [n] is a safe `int`. Throws [StateError] if is not a safe `int`.
   void checkSafeIntegerByBigInt(BigInt n) {
     if (!isSafeIntegerByBigInt(n)) {
       throw StateError(_sageErrorMessage(n));
@@ -52,35 +72,47 @@ abstract class DataSerializerPlatform {
     return '$type out of safe `int` range (platform with $safeIntBits bits precision): minSafe:$minSafeInt < n:$n < maxSafe:$maxSafeInt';
   }
 
+  /// Sets [data] bytes from [offset] with [n] as `Uint64` in [endian] order.
   void setUint64(ByteData data, int n,
       [int offset = 0, Endian endian = Endian.big]);
 
+  /// Sets [data] bytes from [offset] with [n] as `Int64` in [endian] order.
   void setInt64(ByteData data, int n,
       [int offset = 0, Endian endian = Endian.big]);
 
+  /// Sets [data] bytes from [offset] with [n] as `Uint64` in [endian] order.
   void setDataTypeHandlerUint64(IntCodec data, int n,
       [int offset = 0, Endian endian = Endian.big]);
 
+  /// Sets [data] bytes from [offset] with [n] as `Int64` in [endian] order.
   void setDataTypeHandlerInt64(IntCodec data, int n,
       [int offset = 0, Endian endian = Endian.big]);
 
+  /// Gets a `Uint64` from [data] at [offset] in [endian] order.
   int getUint64(ByteData data, [int offset = 0, Endian endian = Endian.big]);
 
+  /// Gets a `Int64` from [data] at [offset] in [endian] order.
   int getInt64(ByteData data, [int offset = 0, Endian endian = Endian.big]);
 
+  /// Gets a `Uint64` from [data] at [offset] in [endian] order.
   int getDataTypeHandlerUint64(IntCodec data,
       [int offset = 0, Endian endian = Endian.big]);
 
+  /// Gets a `Int64` from [data] at [offset] in [endian] order.
   int getDataTypeHandlerInt64(IntCodec data,
       [int offset = 0, Endian endian = Endian.big]);
 
+  /// Writes [n] as `Uint64` to [out] at [offset] in [endian] order.
   void writeUint64(Uint8List out, int n,
       [int offset = 0, Endian endian = Endian.big]);
 
+  /// Writes [n] as `Int64` to [out] at [offset] in [endian] order.
   void writeInt64(Uint8List out, int n,
       [int offset = 0, Endian endian = Endian.big]);
 
+  /// Reads a `Uint64` from [out] at [offset] in [endian] order.
   int readUint64(Uint8List out, [int offset = 0, Endian endian = Endian.big]);
 
+  /// Reads a `Int64` from [out] at [offset] in [endian] order.
   int readInt64(Uint8List out, [int offset = 0, Endian endian = Endian.big]);
 }

--- a/lib/src/platform.dart
+++ b/lib/src/platform.dart
@@ -28,10 +28,10 @@ abstract class DataSerializerPlatform {
   int get minSafeInt;
 
   /// The maximum safe `int` int the current platform as [BigInt].
-  BigInt get maxSafeIntAsBigInt => BigInt.from(maxSafeInt);
+  BigInt get maxSafeIntAsBigInt => _maxSafeBigInt;
 
   /// The minimum safe `int` int the current platform as [BigInt].
-  BigInt get minSafeIntAsBigInt => BigInt.from(minSafeInt);
+  BigInt get minSafeIntAsBigInt => _minSafeBigInt;
 
   /// The maximum safe `int` int the current platform as [Uint8List].
   Uint8List get maxSafeIntBytes;

--- a/test/data_serializer_bytes_buffer_file_test.dart
+++ b/test/data_serializer_bytes_buffer_file_test.dart
@@ -1,5 +1,5 @@
 @TestOn('vm')
-@Tags(['bytes'])
+@Tags(['bytes', 'file'])
 import 'package:data_serializer/data_serializer.dart';
 import 'package:data_serializer/src/bytes_io_file.dart';
 import 'package:test/test.dart';

--- a/test/data_serializer_bytes_buffer_mem_test.dart
+++ b/test/data_serializer_bytes_buffer_mem_test.dart
@@ -1,4 +1,4 @@
-@Tags(['bytes'])
+@Tags(['bytes', 'mem'])
 import 'package:data_serializer/data_serializer.dart';
 import 'package:test/test.dart';
 

--- a/test/data_serializer_bytes_buffer_test_base.dart
+++ b/test/data_serializer_bytes_buffer_test_base.dart
@@ -271,6 +271,9 @@ void doBytesBufferTests(
   });
 
   test('writeUint64/readUint64/readUint32 +', () {
+    final b0 = DataSerializerPlatform.instance.supportsFullInt64 ? 127 : 0;
+    final b1 = DataSerializerPlatform.instance.supportsFullInt64 ? 255 : 31;
+
     var buffer = createBsBuff();
 
     var maxSafeInt = DataSerializerPlatform.instance.maxSafeInt;
@@ -292,10 +295,10 @@ void doBytesBufferTests(
     expect(buffer.readUint32(), equals(maxSafeInt ~/ 0xFFFFFFFF - 1));
     expect(buffer.readUint32(), equals(maxSafeInt & 0xFFFFFFFF));
 
-    expect(buffer.toBytes(), equals([127, 255, 255, 255, 255, 255, 255, 255]));
-    expect(buffer.toBytes(1), equals([255, 255, 255, 255, 255, 255, 255]));
-    expect(buffer.toBytes(0, 2), equals([127, 255]));
-    expect(buffer.toBytes(1, 2), equals([255, 255]));
+    expect(buffer.toBytes(), equals([b0, b1, 255, 255, 255, 255, 255, 255]));
+    expect(buffer.toBytes(1), equals([b1, 255, 255, 255, 255, 255, 255]));
+    expect(buffer.toBytes(0, 2), equals([b0, b1]));
+    expect(buffer.toBytes(1, 2), equals([b1, 255]));
 
     buffer.bytesTo((bytes, offset, length) {
       expect(

--- a/test/data_serializer_bytes_io_file_test.dart
+++ b/test/data_serializer_bytes_io_file_test.dart
@@ -1,4 +1,5 @@
-@Tags(['bytes'])
+@TestOn('vm')
+@Tags(['bytes', 'file'])
 import 'dart:io';
 
 import 'package:data_serializer/src/bytes_io_file.dart';

--- a/test/data_serializer_bytes_io_mem_test.dart
+++ b/test/data_serializer_bytes_io_mem_test.dart
@@ -1,4 +1,4 @@
-@Tags(['bytes'])
+@Tags(['bytes', 'mem'])
 import 'package:data_serializer/data_serializer.dart';
 import 'package:test/test.dart';
 

--- a/test/data_serializer_extension_64bits_test.dart
+++ b/test/data_serializer_extension_64bits_test.dart
@@ -1,0 +1,139 @@
+@TestOn('vm')
+import 'dart:typed_data';
+
+import 'package:data_serializer/data_serializer.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('extension', () {
+    setUp(() {});
+
+    test('ListGenericExtension', () {
+      var l2 = [10, 20, 30, 40, 50, 60, 70, 80];
+
+      // ignore: unnecessary_cast
+      expect((l2.toUint64List() as List<int>).copy(),
+          allOf(equals([10, 20, 30, 40, 50, 60, 70, 80]), isA<Uint64List>()));
+
+      // ignore: unnecessary_cast
+      expect((l2.toInt64List() as List<int>).copy(),
+          allOf(equals([10, 20, 30, 40, 50, 60, 70, 80]), isA<Int64List>()));
+    });
+
+    test('ListIntDataExtension', () {
+      var l1 = [1, 2, 3, 4, 5, 6, 7, 8];
+
+      expect(l1.toUint64List(),
+          allOf(equals([1, 2, 3, 4, 5, 6, 7, 8]), isA<Uint64List>()));
+
+      expect(l1.asUint64List,
+          allOf(equals([1, 2, 3, 4, 5, 6, 7, 8]), isA<Uint64List>()));
+      expect(l1.toUint64List().asUint64List, isA<Uint64List>());
+
+      expect(l1.toInt64List(),
+          allOf(equals([1, 2, 3, 4, 5, 6, 7, 8]), isA<Int64List>()));
+
+      expect(l1.asInt64List,
+          allOf(equals([1, 2, 3, 4, 5, 6, 7, 8]), isA<Int64List>()));
+      expect(l1.toUint64List().asInt64List, isA<Int64List>());
+    });
+
+    test('Uint32ListDataExtension', () {
+      // Force a JS safe integer:
+      var bytes2 = [0, 2, 3, 4, 5, 6, 7, 8].toUint8List();
+      var ns32b = bytes2.convertToUint32List();
+
+      expect(ns32b.convertToUint64List(), equals([0x02030405060708]));
+      expect(ns32b.convertToUint64List(Endian.big), equals([0x02030405060708]));
+      expect(ns32b.convertToUint64List(Endian.little),
+          equals([0x0807060504030200]));
+    });
+
+    test('Uint64ListDataExtension', () {
+      // Force a JS safe integer:
+      var bytes =
+          [0, 2, 3, 4, 5, 6, 7, 8, 0, 3, 4, 5, 6, 7, 8, 9].toUint8List();
+
+      var ns64 = bytes.convertToUint64List();
+      expect(ns64, equals([0x02030405060708, 0x03040506070809]));
+
+      expect(ns64.reversedList(), equals([0x03040506070809, 0x02030405060708]));
+
+      expect(ns64.copy(), equals([0x02030405060708, 0x03040506070809]));
+
+      expect(
+          ns64.copyAsUnmodifiable(),
+          allOf(equals([0x02030405060708, 0x03040506070809]),
+              isA<UnmodifiableUint64ListView>()));
+
+      expect(
+          ns64.asUnmodifiableView,
+          allOf(equals([0x02030405060708, 0x03040506070809]),
+              isA<UnmodifiableUint64ListView>()));
+
+      expect(ns64.toHex64(), equals('0002030405060708 0003040506070809'));
+      expect(
+          ns64.toBits64(),
+          equals(
+              '0000000000000010000000110000010000000101000001100000011100001000 '
+              '0000000000000011000001000000010100000110000001110000100000001001'));
+
+      expect(ns64.convertToUint8List(),
+          equals([0, 2, 3, 4, 5, 6, 7, 8, 0, 3, 4, 5, 6, 7, 8, 9]));
+
+      expect(ns64.convertToUint8List(Endian.big),
+          equals([0, 2, 3, 4, 5, 6, 7, 8, 0, 3, 4, 5, 6, 7, 8, 9]));
+
+      expect(ns64.convertToUint8List(Endian.little),
+          equals([8, 7, 6, 5, 4, 3, 2, 0, 9, 8, 7, 6, 5, 4, 3, 0]));
+
+      expect(
+          ns64.convertToUint16List(),
+          equals([
+            0x0002,
+            0x0304,
+            0x0506,
+            0x0708,
+            0x0003,
+            0x0405,
+            0x0607,
+            0x0809
+          ]));
+
+      expect(
+          ns64.convertToUint16List(Endian.big),
+          equals([
+            0x0002,
+            0x0304,
+            0x0506,
+            0x0708,
+            0x0003,
+            0x0405,
+            0x0607,
+            0x0809
+          ]));
+
+      expect(
+          ns64.convertToUint16List(Endian.little),
+          equals([
+            0x0200,
+            0x0403,
+            0x0605,
+            0x0807,
+            0x0300,
+            0x0504,
+            0x0706,
+            0x0908
+          ]));
+
+      expect(ns64.convertToUint32List(),
+          equals([0x0020304, 0x05060708, 0x00030405, 0x06070809]));
+
+      expect(ns64.convertToUint32List(Endian.big),
+          equals([0x0020304, 0x05060708, 0x00030405, 0x06070809]));
+
+      expect(ns64.convertToUint32List(Endian.little),
+          equals([0x04030200, 0x08070605, 0x05040300, 0x09080706]));
+    });
+  });
+}

--- a/test/data_serializer_extension_test.dart
+++ b/test/data_serializer_extension_test.dart
@@ -66,14 +66,6 @@ void main() {
       expect((l2.toInt32List() as List<int>).copy(),
           allOf(equals([10, 20, 30, 40, 50, 60, 70, 80]), isA<Int32List>()));
 
-      // ignore: unnecessary_cast
-      expect((l2.toUint64List() as List<int>).copy(),
-          allOf(equals([10, 20, 30, 40, 50, 60, 70, 80]), isA<Uint64List>()));
-
-      // ignore: unnecessary_cast
-      expect((l2.toInt64List() as List<int>).copy(),
-          allOf(equals([10, 20, 30, 40, 50, 60, 70, 80]), isA<Int64List>()));
-
       expect(l2.reverseChunks(2), equals([20, 10, 40, 30, 60, 50, 80, 70]));
 
       expect(l2.reverseChunks(4), equals([40, 30, 20, 10, 80, 70, 60, 50]));
@@ -133,20 +125,6 @@ void main() {
           allOf(equals([1, 2, 3, 4, 5, 6, 7, 8]), isA<Int32List>()));
       expect(l1.toUint32List().asInt32List, isA<Int32List>());
 
-      expect(l1.toUint64List(),
-          allOf(equals([1, 2, 3, 4, 5, 6, 7, 8]), isA<Uint64List>()));
-
-      expect(l1.asUint64List,
-          allOf(equals([1, 2, 3, 4, 5, 6, 7, 8]), isA<Uint64List>()));
-      expect(l1.toUint64List().asUint64List, isA<Uint64List>());
-
-      expect(l1.toInt64List(),
-          allOf(equals([1, 2, 3, 4, 5, 6, 7, 8]), isA<Int64List>()));
-
-      expect(l1.asInt64List,
-          allOf(equals([1, 2, 3, 4, 5, 6, 7, 8]), isA<Int64List>()));
-      expect(l1.toUint64List().asInt64List, isA<Int64List>());
-
       expect(l1.toUint8List().convertToUint16List(),
           allOf(equals([0x0102, 0x0304, 0x0506, 0x0708]), isA<Uint16List>()));
 
@@ -192,11 +170,6 @@ void main() {
       expect(ns32b, equals([0x020304, 0x05060708]));
       expect(ns32b.toHex32(), equals('00020304 05060708'));
 
-      expect(ns32b.convertToUint64List(), equals([0x02030405060708]));
-      expect(ns32b.convertToUint64List(Endian.big), equals([0x02030405060708]));
-      expect(ns32b.convertToUint64List(Endian.little),
-          equals([0x0807060504030200]));
-
       expect(ns32b.convertToUint16List(),
           equals([0x0002, 0x0304, 0x0506, 0x0708]));
       expect(ns32b.convertToUint16List(Endian.big),
@@ -210,93 +183,6 @@ void main() {
           equals([0x00, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]));
       expect(ns32b.convertToUint8List(Endian.little),
           equals([0x04, 0x03, 0x02, 0x00, 0x08, 0x07, 0x06, 0x05]));
-    });
-
-    test('Uint64ListDataExtension', () {
-      // Force a JS safe integer:
-      var bytes =
-          [0, 2, 3, 4, 5, 6, 7, 8, 0, 3, 4, 5, 6, 7, 8, 9].toUint8List();
-
-      var ns64 = bytes.convertToUint64List();
-      expect(ns64, equals([0x02030405060708, 0x03040506070809]));
-
-      expect(ns64.reversedList(), equals([0x03040506070809, 0x02030405060708]));
-
-      expect(ns64.copy(), equals([0x02030405060708, 0x03040506070809]));
-
-      expect(
-          ns64.copyAsUnmodifiable(),
-          allOf(equals([0x02030405060708, 0x03040506070809]),
-              isA<UnmodifiableUint64ListView>()));
-
-      expect(
-          ns64.asUnmodifiableView,
-          allOf(equals([0x02030405060708, 0x03040506070809]),
-              isA<UnmodifiableUint64ListView>()));
-
-      expect(ns64.toHex64(), equals('0002030405060708 0003040506070809'));
-      expect(
-          ns64.toBits64(),
-          equals(
-              '0000000000000010000000110000010000000101000001100000011100001000 '
-              '0000000000000011000001000000010100000110000001110000100000001001'));
-
-      expect(ns64.convertToUint8List(),
-          equals([0, 2, 3, 4, 5, 6, 7, 8, 0, 3, 4, 5, 6, 7, 8, 9]));
-
-      expect(ns64.convertToUint8List(Endian.big),
-          equals([0, 2, 3, 4, 5, 6, 7, 8, 0, 3, 4, 5, 6, 7, 8, 9]));
-
-      expect(ns64.convertToUint8List(Endian.little),
-          equals([8, 7, 6, 5, 4, 3, 2, 0, 9, 8, 7, 6, 5, 4, 3, 0]));
-
-      expect(
-          ns64.convertToUint16List(),
-          equals([
-            0x0002,
-            0x0304,
-            0x0506,
-            0x0708,
-            0x0003,
-            0x0405,
-            0x0607,
-            0x0809
-          ]));
-
-      expect(
-          ns64.convertToUint16List(Endian.big),
-          equals([
-            0x0002,
-            0x0304,
-            0x0506,
-            0x0708,
-            0x0003,
-            0x0405,
-            0x0607,
-            0x0809
-          ]));
-
-      expect(
-          ns64.convertToUint16List(Endian.little),
-          equals([
-            0x0200,
-            0x0403,
-            0x0605,
-            0x0807,
-            0x0300,
-            0x0504,
-            0x0706,
-            0x0908
-          ]));
-
-      expect(ns64.convertToUint32List(),
-          equals([0x0020304, 0x05060708, 0x00030405, 0x06070809]));
-
-      expect(ns64.convertToUint32List(Endian.big),
-          equals([0x0020304, 0x05060708, 0x00030405, 0x06070809]));
-
-      expect(ns64.convertToUint32List(Endian.little),
-          equals([0x04030200, 0x08070605, 0x05040300, 0x09080706]));
     });
 
     test('Uint8ListDataExtension', () {

--- a/test/data_serializer_platform_test.dart
+++ b/test/data_serializer_platform_test.dart
@@ -95,6 +95,9 @@ void main() {
     setUp(() {});
 
     test('53 bits Limits', () {
+      expect(p.maxSafeIntAsBigInt, equals(BigInt.from(p.maxSafeInt)));
+      expect(p.minSafeIntAsBigInt, equals(BigInt.from(p.minSafeInt)));
+
       expect(p.isSafeInteger(9007199254740991), isTrue);
       expect(p.isSafeInteger(-9007199254740991), isTrue);
 
@@ -112,6 +115,31 @@ void main() {
 
       expect(BigInt.from(9007199254740991).isSafeInteger, isTrue);
       BigInt.from(9007199254740991).checkSafeInteger();
+
+      expect(BigInt.parse('9007199254740991').isSafeInteger, isTrue);
+      expect(BigInt.parse('-9007199254740991').isSafeInteger, isTrue);
+
+      expect(BigInt.parse('9999999007199254740991').isSafeInteger, isFalse);
+      expect(BigInt.parse('-9999999007199254740991').isSafeInteger, isFalse);
+
+      expect(
+          () => p.checkSafeInteger(9007199254740991), isNot(throwsStateError));
+      expect(
+          () => p.checkSafeInteger(-9007199254740991), isNot(throwsStateError));
+
+      expect(() => p.checkSafeIntegerByBigInt(BigInt.from(9007199254740991)),
+          isNot(throwsStateError));
+      expect(() => p.checkSafeIntegerByBigInt(BigInt.from(-9007199254740991)),
+          isNot(throwsStateError));
+
+      expect(
+          () => p
+              .checkSafeIntegerByBigInt(BigInt.parse('9999999007199254740991')),
+          throwsStateError);
+      expect(
+          () => p.checkSafeIntegerByBigInt(
+              BigInt.parse('-9999999007199254740991')),
+          throwsStateError);
     });
 
     test('64 bits Limits', () {

--- a/test/data_serializer_platform_test.dart
+++ b/test/data_serializer_platform_test.dart
@@ -1,10 +1,27 @@
 @Tags(['num', 'platform'])
+import 'dart:math';
 import 'dart:typed_data';
 
 import 'package:data_serializer/data_serializer.dart';
 import 'package:test/test.dart';
 
-const testSafeNumbers = {
+const testSafeNumbers = <int, String>{
+  4295161520: '00000001 0002F6B0',
+  -4295161520: 'FFFFFFFE FFFD0950',
+  -1048575: 'FFFFFFFF FFF00001',
+  -16777215: 'FFFFFFFF FF000001',
+  -268435455: 'FFFFFFFF F0000001',
+  -4294967295: 'FFFFFFFF 00000001',
+  -4294967296: 'FFFFFFFF00000000',
+  -68719476735: 'FFFFFFF0 00000001',
+  -68451041279: 'FFFFFFF0 10000001',
+  -1099243192319: 'FFFFFF00 10000001',
+  -281474708275199: 'FFFF0000 10000001',
+  -281470413307903: 'FFFF0001 10000001',
+  -4503599358935039: 'FFF00000 10000001',
+  4222124650659841: '000F0000 00000001',
+  4503595332403201: '000FFFFF 00000001',
+  4222128945627137: '000F0001 00000001',
   1: '00000000 00000001',
   -1: 'FFFFFFFF FFFFFFFF',
   2: '00000000 00000002',
@@ -13,13 +30,13 @@ const testSafeNumbers = {
   -123: 'FFFFFFFF FFFFFF85',
   70123: '00000000 000111EB',
   268435455: '00000000 0FFFFFFF',
-  -268435455: 'FFFFFFFF F0000001',
+  //-268435455: 'FFFFFFFF F0000001',
   267324344: '00000000 0FEF0BB8',
   -267324344: 'FFFFFFFF F010F448',
   4294967296: '00000001 00000000',
-  -4294967296: 'FFFFFFFF 00000000',
+  //-4294967296: 'FFFFFFFF 00000000',
   4294967295: '00000000 FFFFFFFF',
-  -4294967295: 'FFFFFFFF 00000001',
+  //-4294967295: 'FFFFFFFF 00000001',
   4294967294: '00000000 FFFFFFFE',
   -4294967294: 'FFFFFFFF 00000002',
   4294967293: '00000000 FFFFFFFD',
@@ -29,7 +46,7 @@ const testSafeNumbers = {
   4294665294: '00000000 FFFB644E',
   -4294665294: 'FFFFFFFF 00049BB2',
   68719476735: '0000000F FFFFFFFF',
-  -68719476735: 'FFFFFFF0 00000001',
+  //-68719476735: 'FFFFFFF0 00000001',
   1099511627775: '000000FF FFFFFFFF',
   -1099511627775: 'FFFFFF00 00000001',
   17592186044415: '00000FFF FFFFFFFF',
@@ -45,7 +62,7 @@ const testSafeNumbers = {
 final p = DataSerializerPlatform();
 
 void _testNumber(int n, String result) {
-  print('---> $n > ${(n >> 32).toHex32()} + ${n.toHex32()}');
+  print('---> $n > ${(n ~/ 0xFFFFFFFF).toHex32()} + ${n.toHex32()}');
 
   var r64 = result.replaceAll(RegExp(r'\s'), '').decodeHex();
   expect(r64.length, equals(8));
@@ -64,8 +81,7 @@ void _testNumber(int n, String result) {
   int nRead1 = p.readUint64(bs1);
   int nRead2 = p.readInt64(bs2);
 
-  expect(nRead1, equals(n),
-      reason: 'n: $n > ${n.toHex64()} != $nRead1 > ${nRead1.toHex64()}');
+  expect(nRead1, equals(n));
   expect(nRead2, equals(n));
 
   expect(p.isSafeInteger(n), isTrue,
@@ -101,9 +117,10 @@ void main() {
     test('64 bits Limits', () {
       var max64 = BigInt.parse('9223372036854775807');
       var min64 = BigInt.parse('-9223372036854775808');
+      var rangMargin = BigInt.from(1024);
 
-      var outUpper64 = max64 + BigInt.from(1024);
-      var outLower64 = min64 - BigInt.from(1024);
+      var outUpper64 = max64 + rangMargin;
+      var outLower64 = min64 - rangMargin;
 
       if (p.supportsFullInt64) {
         expect(p.isSafeIntegerByBigInt(max64), isTrue);
@@ -132,21 +149,28 @@ void main() {
         print('** Testing testSafeNumbers: ${testSafeNumbers.length}');
 
         for (var e in testSafeNumbers.entries) {
-          _testNumber(e.key, e.value);
+          var n = e.key;
+          var result = e.value;
+          _testNumber(n, result);
         }
       },
       //skip: true,
+      tags: 'safe_numbers',
     );
 
     test(
-      'test sequence',
+      'test sequence 1',
       () {
-        for (var endian in [Endian.big, Endian.little]) {
+        for (var endian in [Endian.little, Endian.big]) {
           print(
               '** Testing numbers sequence (${endian == Endian.big ? 'BE' : 'LE'})...');
 
+          var rand = Random(74818365);
+
           var total = 0;
-          for (var n = 0xAA; n < 0xFFFFFFFFFF; n += (255 * 255 * 3)) {
+          for (var n = 0xAA;
+              n < 0xFFFFFFFFFFFF;
+              n += rand.nextInt(255 * 255 * 256 * 3 * 3)) {
             var bs1 = Uint8List(8);
             var bs2 = Uint8List(8);
 
@@ -154,10 +178,11 @@ void main() {
             p.writeInt64(bs2, n, 0, endian);
 
             var nRead1 = p.readUint64(bs1, 0, endian);
-            var nRead2 = p.readUint64(bs1, 0, endian);
+            var nRead2 = p.readUint64(bs2, 0, endian);
 
-            expect(nRead1, equals(n));
-            expect(nRead2, equals(n));
+            var endianName = endian.isBigEndian ? 'big' : 'little';
+            expect(nRead1, equals(n), reason: "endian: $endianName");
+            expect(nRead2, equals(n), reason: "endian: $endianName");
             total++;
           }
 
@@ -168,14 +193,18 @@ void main() {
     );
 
     test(
-      'test sequence',
+      'test sequence 2',
       () {
-        for (var endian in [Endian.big, Endian.little]) {
+        for (var endian in [Endian.little, Endian.big]) {
           print(
               '** Testing numbers sequence (${endian == Endian.big ? 'BE' : 'LE'})...');
 
+          var rand = Random(3847592812);
+
           var total = 0;
-          for (var n = 0xAA; n < 0xFFFFFFFFFF; n += (255 * 255 * 3)) {
+          for (var n = 0xAA;
+              n < 0xFFFFFFFFFFFF;
+              n += rand.nextInt(255 * 255 * 256 * 3 * 4)) {
             var bs1a = Uint8List(8);
             var bs2a = Uint8List(8);
             var bsh1a = ByteDataIntCodec(bs1a.asByteData());


### PR DESCRIPTION
- New `BytesIO`:
  - Implementations: `BytesFileIO` and `BytesUint8ListIO`.
- Added constructor `BytesBuffer.fromIO`.
- `DataSerializerPlatformGeneric`:
  - Fixed `_writeInt64` and `_readInt64` for JS/Browser platform.

- Dart CI:
  - Tests platforms: vm, exe, chrome.

- sdk: '>=2.18.4 <4.0.0'
- collection: ^1.18.0
- lints: ^2.0.1
- test: ^1.24.3
- dependency_validator: ^3.2.2
- coverage: ^1.6.3