### PR TITLE
v1.0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 1.0.12
+
+- New `BitsBuffer`.
+- `BytesBuffer`:
+  - `writeWritables/readWritables`: new parameter option `leb128`.
+  - Added `writeFloat64`, `writeAllFloat64`, `readFloat64` and `readAllFloat64`.
+  - Added `writeFloat32`, `writeAllFloat32`, `readFloat32` and `readAllFloat32`.
+  - Added `readTo` and `writeFrom`.
+
+- test: ^1.24.8
+
 ## 1.0.11
 
 - Added support to `Leb128`.

--- a/lib/data_serializer.dart
+++ b/lib/data_serializer.dart
@@ -1,6 +1,7 @@
 /// Library to handle data serialization/deserialization efficiently.
 library data_serializer;
 
+export 'src/bits_buffer.dart';
 export 'src/bytes_buffer.dart';
 export 'src/bytes_emitter.dart';
 export 'src/bytes_io.dart';

--- a/lib/src/bits_buffer.dart
+++ b/lib/src/bits_buffer.dart
@@ -9,10 +9,13 @@ class BitsBuffer {
   BitsBuffer([int initialCapacity = 32])
       : _bytesBuffer = BytesBuffer(initialCapacity);
 
+  BitsBuffer.from(BytesBuffer bytes) : _bytesBuffer = bytes;
+
+  BitsBuffer.fromBytes(List<int> bytes)
+      : this.from(BytesBuffer.from(bytes.asUint8List));
+
   /// The internal [BytesBuffer].
   BytesBuffer get bytesBuffer => _bytesBuffer;
-
-  BitsBuffer.from(BytesBuffer bytes) : _bytesBuffer = bytes;
 
   int seek(int position) => _bytesBuffer.seek(position);
 

--- a/lib/src/bits_buffer.dart
+++ b/lib/src/bits_buffer.dart
@@ -177,13 +177,14 @@ class BitsBuffer {
     return b;
   }
 
-  /// Writes padding bits to ensure proper byte alignment.
+  /// Writes padding bits to ensure proper byte alignment and
+  /// returns the length of the written padding.
   ///
   /// Since data is flushed in blocks of 8 bits (bytes), if the internal buffer's
   /// size is not a multiple of 8, padding bits are needed to ensure that the
   /// remaining bits are properly flushed.
   ///
-  /// The padding format consists of a `1` bit (the head) and an optional
+  /// The padding format consists of a `1` bit (the head) followed by an optional
   /// sequence of `0` bits until a full byte is completed.
   ///
   /// Example:
@@ -197,17 +198,18 @@ class BitsBuffer {
   ///   is written to [bytesBuffer].
   ///
   /// See [isAtPadding].
-  void writePadding() {
+  int writePadding() {
     if (_bitsBufferLength == 0) {
       var padding = (1 << 7);
       _bytesBuffer.writeByte(padding);
+      return 8;
     } else {
       final gapBits = 8 - _bitsBufferLength;
       assert(gapBits > 0);
 
       var padding = 1 << (gapBits - 1);
 
-      writeBits(padding, gapBits);
+      return writeBits(padding, gapBits);
     }
   }
 

--- a/lib/src/bits_buffer.dart
+++ b/lib/src/bits_buffer.dart
@@ -1,0 +1,292 @@
+import 'dart:typed_data';
+
+import 'package:data_serializer/data_serializer.dart';
+
+/// A buffer of bits over a [BytesBuffer].
+class BitsBuffer {
+  final BytesBuffer _bytesBuffer;
+
+  BitsBuffer([int initialCapacity = 32])
+      : _bytesBuffer = BytesBuffer(initialCapacity);
+
+  /// The internal [BytesBuffer].
+  BytesBuffer get bytesBuffer => _bytesBuffer;
+
+  BitsBuffer.from(BytesBuffer bytes) : _bytesBuffer = bytes;
+
+  int seek(int position) => _bytesBuffer.seek(position);
+
+  /// The position of the [bytesBuffer].
+  int get position => _bytesBuffer.position;
+
+  /// The length of the [bytesBuffer].
+  int get length => _bytesBuffer.length;
+
+  /// The remaining bytes of the [bytesBuffer].
+  int get remaining => _bytesBuffer.remaining;
+
+  int _bitsBuffer = 0;
+  int _bitsBufferLength = 0;
+
+  /// Returns `true` if there are any remaining bits that haven't been written
+  /// to the [bytesBuffer].
+  bool get hasUnflushedBits => _bitsBufferLength > 0;
+
+  /// Returns the length of unflushed bits in the internal bit buffer. See [hasUnflushedBits].
+  int get unflushedBitsLength => _bitsBufferLength;
+
+  /// Checks for unflushed bits using [hasUnflushedBits] and throws a [StateError]
+  /// if there are any bits that haven't been written.
+  void checkUnflushedBits() {
+    if (hasUnflushedBits) {
+      throw StateError("Unflushed bits: $_bitsBufferLength");
+    }
+  }
+
+  /// Writes a byte [b].
+  int writeByte(int b) {
+    if (_bitsBufferLength == 0) {
+      _bytesBuffer.writeByte(b & 0xFF);
+      return 1;
+    }
+
+    writeBits(b, 8);
+    return 1;
+  }
+
+  /// Writes a list of bytes.
+  int writeBytes(List<int> bs) {
+    if (_bitsBufferLength == 0) {
+      _bytesBuffer.writeAll(bs);
+      return 1;
+    }
+
+    final length = bs.length;
+    for (var i = 0; i < length; ++i) {
+      writeByte(bs[i]);
+    }
+
+    return length;
+  }
+
+  /// Writes a [bit] (`true`: `1` ; `false`: `0`).
+  /// Returns the number of bits successfully written into the buffer.
+  ///
+  /// Note that a byte is written to the internal [bytesBuffer] for every 8 accumulated bits.
+  /// See [writeBits] and [unflushedBitsLength].
+  int writeBit(bool bit) {
+    return writeBits(bit ? 1 : 0, 1);
+  }
+
+  /// Writes the specified number of bits from the given integer value into the internal [bytesBuffer].
+  ///
+  /// Parameters:
+  /// - `bits`: The integer containing the bits to be written.
+  /// - `bitsLength`: The number of bits to write from the `bits` integer.
+  ///
+  /// Returns the number of bits successfully written into the buffer.
+  ///
+  /// Note that a byte is written to the internal [bytesBuffer] for every 8 accumulated bits.
+  /// See [writeBit] and [unflushedBitsLength].
+  int writeBits(int bits, int bitsLength) {
+    if (bitsLength == 8 && _bitsBufferLength == 0) {
+      _bytesBuffer.writeByte(bits & 0xFF);
+      return 8;
+    }
+
+    var bitsWrote = 0;
+
+    while (bitsLength > 0) {
+      var bufferRemaining = 8 - _bitsBufferLength;
+      assert(bufferRemaining > 0);
+
+      var bitsLng = bitsLength;
+      if (bitsLng > bufferRemaining) {
+        bitsLng = bufferRemaining;
+      }
+      assert(bitsLng >= 1 && bitsLng <= 8);
+
+      var bitsExtra = bitsLength - bitsLng;
+
+      var bMask = (1 << bitsLng) - 1;
+      assert(bMask > 0);
+      var bMask2 = (1 << bitsExtra) - 1;
+
+      _bitsBuffer = (_bitsBuffer << bitsLng) | ((bits >> bitsExtra) & bMask);
+      _bitsBufferLength += bitsLng;
+      bits = bits & bMask2;
+
+      bitsWrote += bitsLng;
+      bitsLength -= bitsLng;
+
+      assert(_bitsBufferLength >= 1 && _bitsBufferLength <= 8);
+
+      if (_bitsBufferLength == 8) {
+        _bytesBuffer.writeByte(_bitsBuffer);
+        _bitsBuffer = 0;
+        _bitsBufferLength = 0;
+      }
+    }
+
+    return bitsWrote;
+  }
+
+  /// Reads a byte.
+  int readByte() => readBits(8);
+
+  /// Reads a bit.
+  int readBit() {
+    return readBits(1);
+  }
+
+  /// Reads and returns the specified number of bits from the internal buffer.
+  ///
+  /// Parameters:
+  /// - `bitsLength`: The number of bits to be read from the internal buffer.
+  ///
+  /// Returns an integer containing the read bits.
+  int readBits(int bitsLength) {
+    if (bitsLength == 8 && _bitsBufferLength == 0) {
+      return _bytesBuffer.readByte();
+    }
+
+    while (_bitsBufferLength < bitsLength) {
+      var rb = _bytesBuffer.readByte();
+      _bitsBuffer = (_bitsBuffer << 8) | (rb & 0xFF);
+      _bitsBufferLength += 8;
+    }
+
+    if (bitsLength == _bitsBufferLength) {
+      var b = _bitsBuffer;
+      _bitsBuffer = 0;
+      _bitsBufferLength = 0;
+      return b;
+    }
+
+    var extraBits = _bitsBufferLength - bitsLength;
+
+    var bMask = (1 << bitsLength) - 1;
+    assert(bMask > 0);
+    var bMask2 = (1 << extraBits) - 1;
+
+    var b = (_bitsBuffer >>> extraBits) & bMask;
+
+    _bitsBuffer = _bitsBuffer & bMask2;
+    _bitsBufferLength -= bitsLength;
+
+    return b;
+  }
+
+  /// Writes padding bits to ensure proper byte alignment.
+  ///
+  /// Since data is flushed in blocks of 8 bits (bytes), if the internal buffer's
+  /// size is not a multiple of 8, padding bits are needed to ensure that the
+  /// remaining bits are properly flushed.
+  ///
+  /// The padding format consists of a `1` bit (the head) and an optional
+  /// sequence of `0` bits until a full byte is completed.
+  ///
+  /// Example:
+  /// - If the internal unflushed buffer contains 5 bits (e.g., `00110`) and
+  ///   you call [writePadding], it will add a `1` bit and 2 `0` bits (`100`)
+  ///   to the buffer, completing the byte to flush (`00110100`). This ensures
+  ///   that the unflushed bits can be written to [bytesBuffer] and later be
+  ///   read, with knowledge of how to remove the padding.
+  ///
+  /// - If there are no unflushed bits, a full padding byte (`10000000`)
+  ///   is written to [bytesBuffer].
+  ///
+  /// See [isAtPadding].
+  void writePadding() {
+    if (_bitsBufferLength == 0) {
+      var padding = (1 << 7);
+      _bytesBuffer.writeByte(padding);
+    } else {
+      final gapBits = 8 - _bitsBufferLength;
+      assert(gapBits > 0);
+
+      var padding = 1 << (gapBits - 1);
+
+      writeBits(padding, gapBits);
+    }
+  }
+
+  /// If the current buffer is at the padding position, it consumes the padding
+  /// bits and then returns `true`.
+  /// If not, it simply returns `false` without changing the internal buffer's
+  /// status or position.
+  ///
+  /// If the [paddingPosition] is not explicitly passed, its value will be set
+  /// to the last byte position of the [bytesBuffer].
+  bool isAtPadding({int? paddingPosition}) {
+    paddingPosition ??= _bytesBuffer.length - 1;
+    final pos = _bytesBuffer.position;
+
+    if (pos >= paddingPosition) {
+      if ((pos == paddingPosition && _bitsBufferLength == 0) ||
+          (pos > paddingPosition && _bitsBufferLength > 0)) {
+        var padding = readPadding();
+        if (padding > 0) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  }
+
+  /// Reads the padding and returns the amount of bits read. If the current
+  /// buffer is not at the padding position, it will return `false` without
+  /// changing the internal buffer's status or position.
+  int readPadding() {
+    if (_bitsBufferLength == 0) {
+      final initPos = _bytesBuffer.position;
+
+      var b = _bytesBuffer.readByte();
+
+      if (b == (1 << 7)) {
+        return 8;
+      } else {
+        _bytesBuffer.seek(initPos);
+        return 0;
+      }
+    }
+
+    final initBitsBuffer = _bitsBuffer;
+    final initBitsBufferLength = _bitsBufferLength;
+
+    final paddingBits = _bitsBufferLength;
+    assert(paddingBits > 0);
+
+    var head = readBits(1);
+    if (head != 1) {
+      _bitsBuffer = initBitsBuffer;
+      _bitsBufferLength = initBitsBufferLength;
+      return 0;
+    }
+
+    for (var i = 1; i < paddingBits; ++i) {
+      var tailBit = readBits(1);
+      if (tailBit != 0) {
+        _bitsBuffer = initBitsBuffer;
+        _bitsBufferLength = initBitsBufferLength;
+        return 0;
+      }
+    }
+    assert(_bitsBufferLength == 0);
+
+    return paddingBits;
+  }
+
+  /// Returns the internal [bytesBuffer] bytes.
+  /// See [BytesBuffer.toBytes].
+  Uint8List toBytes([int offset = 0, int? length]) {
+    checkUnflushedBits();
+    return _bytesBuffer.toBytes(offset, length);
+  }
+
+  @override
+  String toString() {
+    return 'BitsBuffer{unflushedBits: $_bitsBuffer, unflushedBitsLength: $unflushedBitsLength}@$_bytesBuffer';
+  }
+}

--- a/lib/src/bytes_io.dart
+++ b/lib/src/bytes_io.dart
@@ -88,6 +88,12 @@ abstract class BytesIO {
   /// Writes all the `int` at [list] as bytes.
   int writeAll(List<int> list);
 
+  /// Read [length] bytes into [io].
+  int readTo(BytesIO io, [int? length]);
+
+  /// Writes [length] bytes from [io].
+  int writeFrom(BytesIO io, [int? length]);
+
   /// Returns `this` instance as a [Uint8List]. Returns the internal `bytes`
   /// buffer if the [length] and [capacity] is the same, otherwise creates a
   /// copy with the exact [length].

--- a/lib/src/bytes_io_file.dart
+++ b/lib/src/bytes_io_file.dart
@@ -363,6 +363,22 @@ class BytesFileIO extends BytesIO {
   }
 
   @override
+  int readTo(BytesIO io, [int? length]) {
+    length ??= remaining;
+    var bs = readBytes(length);
+    io.writeAll(bs);
+    return bs.length;
+  }
+
+  @override
+  int writeFrom(BytesIO io, [int? length]) {
+    length ??= io.remaining;
+    var bs = io.readBytes(length);
+    writeAll(bs);
+    return bs.length;
+  }
+
+  @override
   Uint8List asUint8List([int offset = 0, int? length]) =>
       toBytes(offset, length);
 

--- a/lib/src/bytes_io_uint8list.dart
+++ b/lib/src/bytes_io_uint8list.dart
@@ -205,6 +205,60 @@ class BytesUint8ListIO extends BytesIO {
   }
 
   @override
+  int readTo(BytesIO io, [int? length]) {
+    length ??= remaining;
+
+    if (io is BytesUint8ListIO) {
+      final bytes = _bytes;
+      final bytes2 = io._bytes;
+
+      final offset = _position;
+      final offset2 = io._position;
+
+      for (var i = 0; i < length; ++i) {
+        var b = bytes[offset + i];
+        bytes2[offset2 + i] = b;
+      }
+
+      incrementPosition(length);
+      io.incrementPosition(length);
+
+      return length;
+    } else {
+      var bs = readBytes(length);
+      io.writeAll(bs);
+      return bs.length;
+    }
+  }
+
+  @override
+  int writeFrom(BytesIO io, [int? length]) {
+    length ??= io.remaining;
+
+    if (io is BytesUint8ListIO) {
+      final bytes = _bytes;
+      final bytes2 = io._bytes;
+
+      final offset = _position;
+      final offset2 = io._position;
+
+      for (var i = 0; i < length; ++i) {
+        var b = bytes2[offset2 + i];
+        bytes[offset + i] = b;
+      }
+
+      incrementPosition(length);
+      io.incrementPosition(length);
+
+      return length;
+    } else {
+      var bs = io.readBytes(length);
+      writeAll(bs);
+      return bs.length;
+    }
+  }
+
+  @override
   Uint8List asUint8List([int offset = 0, int? length]) =>
       _fromUint8List(_bytes, offset, length, _length);
 

--- a/lib/src/leb128.dart
+++ b/lib/src/leb128.dart
@@ -224,6 +224,20 @@ extension BytesBufferLeb128Extension on BytesBuffer {
     return writeAll(block);
   }
 
+  /// Reads a LEB128 bytes block into [dst].
+  int readLeb128BlockTo(BytesBuffer dst) {
+    var blockSize = readLeb128UnsignedInt();
+    return readTo(dst, blockSize);
+  }
+
+  /// Writes a LEB128 bytes [block] from [src].
+  int writeLeb128BlockFrom(BytesBuffer src, [int? length]) {
+    length ??= src.length;
+    var bsLng = Leb128.encodeUnsigned(length);
+    writeAllBytes(bsLng);
+    return writeFrom(src, length) + bsLng.length;
+  }
+
   /// Reads a [String] inside a LEB128 bytes block.
   String readLeb128String(
       {dart_convert.Encoding encoding = dart_convert.latin1}) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: data_serializer
 description: Portable Dart package to handle data serialization/deserialization efficiently, including a dynamic BytesBuffer to read/write data.
-version: 1.0.11
+version: 1.0.12
 homepage: https://github.com/gmpassos/data_serializer
 
 environment:
@@ -12,7 +12,7 @@ dependencies:
 
 dev_dependencies:
   lints: ^2.0.1
-  test: ^1.24.3
+  test: ^1.24.8
   dependency_validator: ^3.2.3
   coverage: ^1.6.3
   path: ^1.8.3

--- a/test/data_serializer_bits_buffer_test.dart
+++ b/test/data_serializer_bits_buffer_test.dart
@@ -283,10 +283,15 @@ void main() {
       expect(buffer.unflushedBitsLength, equals(0));
       expect(buffer.length, equals(lng + 3));
 
-      expect(buffer.writePadding(), equals(8));
+      expect(buffer.writeBits(0xA5, 8), equals(8));
       expect(buffer.hasUnflushedBits, isFalse);
       expect(buffer.unflushedBitsLength, equals(0));
       expect(buffer.length, equals(lng + 4));
+
+      expect(buffer.writePadding(), equals(8));
+      expect(buffer.hasUnflushedBits, isFalse);
+      expect(buffer.unflushedBitsLength, equals(0));
+      expect(buffer.length, equals(lng + 5));
     });
   });
 }

--- a/test/data_serializer_bits_buffer_test.dart
+++ b/test/data_serializer_bits_buffer_test.dart
@@ -6,25 +6,124 @@ void main() {
     test('writeBits: 0xFF @ 1...', () {
       var buffer = BitsBuffer();
 
+      expect(buffer.bytesBuffer.position, equals(0));
+      expect(buffer.bytesBuffer.length, equals(0));
       expect(buffer.unflushedBitsLength, equals(0));
+      expect(buffer.length, equals(0));
+
       expect(buffer.writeBits(1, 1), equals(1));
+      expect(buffer.bytesBuffer.position, equals(0));
+      expect(buffer.bytesBuffer.length, equals(0));
       expect(buffer.unflushedBitsLength, equals(1));
+      expect(buffer.length, equals(0));
+
       expect(buffer.writeBits(1, 1), equals(1));
       expect(buffer.unflushedBitsLength, equals(2));
+      expect(buffer.bytesBuffer.position, equals(0));
+      expect(buffer.bytesBuffer.length, equals(0));
+      expect(buffer.length, equals(0));
+
       expect(buffer.writeBits(1, 1), equals(1));
       expect(buffer.unflushedBitsLength, equals(3));
-      expect(buffer.writeBits(1, 1), equals(1));
+      expect(buffer.bytesBuffer.position, equals(0));
+      expect(buffer.bytesBuffer.length, equals(0));
+      expect(buffer.length, equals(0));
+
+      expect(buffer.writeBit(true), equals(1));
       expect(buffer.unflushedBitsLength, equals(4));
+      expect(buffer.bytesBuffer.position, equals(0));
+      expect(buffer.bytesBuffer.length, equals(0));
+      expect(buffer.length, equals(0));
+
       expect(buffer.writeBits(1, 1), equals(1));
       expect(buffer.unflushedBitsLength, equals(5));
       expect(buffer.writeBits(1, 1), equals(1));
       expect(buffer.unflushedBitsLength, equals(6));
-      expect(buffer.writeBits(1, 1), equals(1));
+      expect(buffer.length, equals(0));
+
+      expect(buffer.writeBit(true), equals(1));
       expect(buffer.unflushedBitsLength, equals(7));
+      expect(buffer.bytesBuffer.position, equals(0));
+      expect(buffer.bytesBuffer.length, equals(0));
+      expect(buffer.length, equals(0));
+      expect(buffer.length, equals(0));
+
       expect(buffer.writeBits(1, 1), equals(1));
       expect(buffer.unflushedBitsLength, equals(0));
+      expect(buffer.bytesBuffer.position, equals(1));
+      expect(buffer.bytesBuffer.length, equals(1));
+      expect(buffer.length, equals(1));
 
       expect(buffer.toBytes(), equals([0xFF]));
+
+      buffer.writeByte(0x02);
+
+      expect(buffer.toBytes(), equals([0xFF, 0x02]));
+
+      buffer.writeBytes([0x03, 0x04]);
+
+      expect(buffer.toBytes(), equals([0xFF, 0x02, 0x03, 0x04]));
+      expect(buffer.hasUnflushedBits, isFalse);
+
+      expect(buffer.writeBits(0x05, 3), equals(3));
+      expect(buffer.hasUnflushedBits, isTrue);
+
+      expect(buffer.writePadding(), 5);
+      expect(buffer.hasUnflushedBits, isFalse);
+      expect(buffer.toBytes(), equals([0xFF, 0x02, 0x03, 0x04, 0xB0]));
+
+      buffer.seek(0);
+
+      var paddingPos = buffer.length - 1;
+
+      expect(buffer.hasUnflushedBits, isFalse);
+      expect(buffer.isAtPadding(paddingPosition: paddingPos), isFalse);
+
+      expect(buffer.readBit(), equals(1));
+      expect(buffer.hasUnflushedBits, isTrue);
+      expect(buffer.position, equals(1));
+      expect(buffer.isAtPadding(paddingPosition: paddingPos), isFalse);
+
+      expect(buffer.readBits(2), equals(0x03));
+      expect(buffer.hasUnflushedBits, isTrue);
+      expect(buffer.position, equals(1));
+      expect(buffer.isAtPadding(paddingPosition: paddingPos), isFalse);
+
+      expect(buffer.readBits(5), equals(0x1F));
+      expect(buffer.hasUnflushedBits, isFalse);
+      expect(buffer.position, equals(1));
+      expect(buffer.isAtPadding(paddingPosition: paddingPos), isFalse);
+
+      expect(buffer.readBits(8), equals(0x02));
+      expect(buffer.hasUnflushedBits, isFalse);
+      expect(buffer.position, equals(2));
+      expect(buffer.isAtPadding(paddingPosition: paddingPos), isFalse);
+
+      expect(buffer.readByte(), equals(0x03));
+      expect(buffer.hasUnflushedBits, isFalse);
+      expect(buffer.position, equals(3));
+      expect(buffer.isAtPadding(paddingPosition: paddingPos), isFalse);
+
+      expect(buffer.readByte(), equals(0x04));
+      expect(buffer.hasUnflushedBits, isFalse);
+      expect(buffer.position, equals(4));
+      expect(buffer.isAtPadding(paddingPosition: paddingPos), isFalse);
+
+      expect(buffer.readBit(), equals(1));
+      expect(buffer.hasUnflushedBits, isTrue);
+      expect(buffer.position, equals(5));
+      expect(buffer.isAtPadding(paddingPosition: paddingPos), isFalse);
+
+      expect(buffer.readBit(), equals(0));
+      expect(buffer.hasUnflushedBits, isTrue);
+      expect(buffer.position, equals(5));
+      expect(buffer.isAtPadding(paddingPosition: paddingPos), isFalse);
+
+      expect(buffer.readBit(), equals(1));
+      expect(buffer.hasUnflushedBits, isTrue);
+      expect(buffer.position, equals(5));
+      expect(buffer.isAtPadding(paddingPosition: paddingPos), isTrue);
+      expect(buffer.hasUnflushedBits, isFalse);
     });
 
     test('writeBits: 0xFF @ 2 3...', () {

--- a/test/data_serializer_bits_buffer_test.dart
+++ b/test/data_serializer_bits_buffer_test.dart
@@ -221,5 +221,72 @@ void main() {
       expect(buffer.unflushedBitsLength, equals(0));
       expect(buffer.remaining, equals(0));
     });
+
+    test('fromBytes', () {
+      var buffer = BitsBuffer.fromBytes([0xA5, 0x5A]);
+
+      expect(buffer.toBytes(), equals([0xA5, 0x5A]));
+
+      expect(buffer.readBits(8), equals(0xA5));
+      expect(buffer.readBits(8), equals(0x5A));
+
+      expect(buffer.hasUnflushedBits, isFalse);
+      expect(buffer.unflushedBitsLength, equals(0));
+
+      expect(buffer.writeBits(0x02, 2), equals(2));
+      expect(buffer.hasUnflushedBits, isTrue);
+      expect(buffer.unflushedBitsLength, equals(2));
+
+      expect(() => buffer.checkUnflushedBits(), throwsA(isA<StateError>()));
+
+      expect(buffer.hasUnflushedBits, isTrue);
+      expect(buffer.unflushedBitsLength, equals(2));
+
+      expect(buffer.writeBits(0x02, 5), equals(5));
+      expect(buffer.hasUnflushedBits, isTrue);
+      expect(buffer.unflushedBitsLength, equals(7));
+
+      expect(() => buffer.checkUnflushedBits(), throwsA(isA<StateError>()));
+
+      expect(buffer.hasUnflushedBits, isTrue);
+      expect(buffer.unflushedBitsLength, equals(7));
+
+      expect(buffer.writeBits(0x01, 1), equals(1));
+      expect(buffer.hasUnflushedBits, isFalse);
+      expect(buffer.unflushedBitsLength, equals(0));
+
+      buffer.checkUnflushedBits();
+
+      expect(buffer.hasUnflushedBits, isFalse);
+
+      var lng = buffer.length;
+
+      expect(buffer.writeBits(0x01, 1), equals(1));
+      expect(buffer.hasUnflushedBits, isTrue);
+      expect(buffer.unflushedBitsLength, equals(1));
+      expect(buffer.length, equals(lng));
+
+      expect(buffer.writeByte(0xff), equals(1));
+      expect(buffer.hasUnflushedBits, isTrue);
+      expect(buffer.unflushedBitsLength, equals(1));
+      expect(buffer.length, equals(lng + 1));
+
+      lng = buffer.length;
+
+      expect(buffer.writeBytes([0xfe, 0xfd]), equals(2));
+      expect(buffer.hasUnflushedBits, isTrue);
+      expect(buffer.unflushedBitsLength, equals(1));
+      expect(buffer.length, equals(lng + 2));
+
+      expect(buffer.writeBits(0xFF, 7), equals(7));
+      expect(buffer.hasUnflushedBits, isFalse);
+      expect(buffer.unflushedBitsLength, equals(0));
+      expect(buffer.length, equals(lng + 3));
+
+      expect(buffer.writePadding(), equals(8));
+      expect(buffer.hasUnflushedBits, isFalse);
+      expect(buffer.unflushedBitsLength, equals(0));
+      expect(buffer.length, equals(lng + 4));
+    });
   });
 }

--- a/test/data_serializer_bits_buffer_test.dart
+++ b/test/data_serializer_bits_buffer_test.dart
@@ -1,0 +1,126 @@
+import 'package:data_serializer/src/bits_buffer.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('BitsBuffer', () {
+    test('writeBits: 0xFF @ 1...', () {
+      var buffer = BitsBuffer();
+
+      expect(buffer.unflushedBitsLength, equals(0));
+      expect(buffer.writeBits(1, 1), equals(1));
+      expect(buffer.unflushedBitsLength, equals(1));
+      expect(buffer.writeBits(1, 1), equals(1));
+      expect(buffer.unflushedBitsLength, equals(2));
+      expect(buffer.writeBits(1, 1), equals(1));
+      expect(buffer.unflushedBitsLength, equals(3));
+      expect(buffer.writeBits(1, 1), equals(1));
+      expect(buffer.unflushedBitsLength, equals(4));
+      expect(buffer.writeBits(1, 1), equals(1));
+      expect(buffer.unflushedBitsLength, equals(5));
+      expect(buffer.writeBits(1, 1), equals(1));
+      expect(buffer.unflushedBitsLength, equals(6));
+      expect(buffer.writeBits(1, 1), equals(1));
+      expect(buffer.unflushedBitsLength, equals(7));
+      expect(buffer.writeBits(1, 1), equals(1));
+      expect(buffer.unflushedBitsLength, equals(0));
+
+      expect(buffer.toBytes(), equals([0xFF]));
+    });
+
+    test('writeBits: 0xFF @ 2 3...', () {
+      var buffer = BitsBuffer();
+      expect(buffer.unflushedBitsLength, equals(0));
+
+      expect(buffer.writeBits(0x3, 2), equals(2));
+      expect(buffer.unflushedBitsLength, equals(2));
+
+      expect(buffer.writeBits(0x7, 3), equals(3));
+      expect(buffer.unflushedBitsLength, equals(5));
+
+      expect(buffer.writeBits(0x7, 3), equals(3));
+      expect(buffer.unflushedBitsLength, equals(0));
+
+      expect(buffer.toBytes(), equals([0xFF]));
+    });
+
+    test('writeBits: 0xD3 @ 1...', () {
+      var buffer = BitsBuffer();
+      expect(buffer.unflushedBitsLength, equals(0));
+
+      expect(buffer.writeBits(1, 1), equals(1));
+      expect(buffer.unflushedBitsLength, equals(1));
+      expect(buffer.writeBits(1, 1), equals(1));
+      expect(buffer.unflushedBitsLength, equals(2));
+      expect(buffer.writeBits(0, 1), equals(1));
+      expect(buffer.unflushedBitsLength, equals(3));
+      expect(buffer.writeBits(1, 1), equals(1));
+      expect(buffer.unflushedBitsLength, equals(4));
+      expect(buffer.writeBits(0, 1), equals(1));
+      expect(buffer.unflushedBitsLength, equals(5));
+      expect(buffer.writeBits(0, 1), equals(1));
+      expect(buffer.unflushedBitsLength, equals(6));
+      expect(buffer.writeBits(1, 1), equals(1));
+      expect(buffer.unflushedBitsLength, equals(7));
+      expect(buffer.writeBits(1, 1), equals(1));
+      expect(buffer.unflushedBitsLength, equals(0));
+
+      expect(buffer.toBytes(), equals([0xD3]));
+    });
+
+    test('writeBits: 0xD3 @ 2...', () {
+      var buffer = BitsBuffer();
+      expect(buffer.unflushedBitsLength, equals(0));
+
+      expect(buffer.writeBits(0x3, 2), equals(2));
+      expect(buffer.unflushedBitsLength, equals(2));
+
+      expect(buffer.writeBits(0x1, 2), equals(2));
+      expect(buffer.unflushedBitsLength, equals(4));
+
+      expect(buffer.writeBits(0, 2), equals(2));
+      expect(buffer.unflushedBitsLength, equals(6));
+
+      expect(buffer.writeBits(0x3, 2), equals(2));
+      expect(buffer.unflushedBitsLength, equals(0));
+
+      expect(buffer.toBytes(), equals([0xD3]));
+    });
+
+    test('writeBits: 0xD3 @ 7 2 7 ; readBits: 1 7', () {
+      var buffer = BitsBuffer();
+      expect(buffer.unflushedBitsLength, equals(0));
+
+      expect(buffer.writeBits(0xFF, 7), equals(7));
+      expect(buffer.unflushedBitsLength, equals(7));
+
+      expect(buffer.writeBits(0x1, 2), equals(2));
+      expect(buffer.unflushedBitsLength, equals(1));
+
+      expect(buffer.writeBits(0xFF, 7), equals(7));
+      expect(buffer.unflushedBitsLength, equals(0));
+
+      expect(buffer.toBytes(), [0xFE, 0xFF]);
+
+      expect(buffer.position, equals(2));
+
+      buffer.seek(0);
+
+      expect(buffer.position, equals(0));
+      expect(buffer.unflushedBitsLength, equals(0));
+
+      expect(buffer.readBits(1), equals(1));
+      expect(buffer.position, equals(1));
+      expect(buffer.unflushedBitsLength, equals(7));
+
+      expect(buffer.readBits(7), equals(0x7E));
+      expect(buffer.position, equals(1));
+      expect(buffer.unflushedBitsLength, equals(0));
+      expect(buffer.remaining, equals(1));
+
+      expect(buffer.readBits(8), equals(0xFF));
+      expect(buffer.position, equals(2));
+      expect(buffer.unflushedBitsLength, equals(0));
+      expect(buffer.remaining, equals(0));
+    });
+  });
+}

--- a/test/data_serializer_bytes_buffer_test_base.dart
+++ b/test/data_serializer_bytes_buffer_test_base.dart
@@ -504,4 +504,45 @@ void doBytesBufferTests(
 
     expect(() => buffer.readBlocks(), throwsA(isA<BytesBufferEOF>()));
   });
+
+  test('writeFloat64/writeAllFloat64', () {
+    var buffer = createBsBuff();
+
+    buffer.writeFloat64(123.456);
+    expect(buffer.length, equals(8));
+
+    buffer.writeAllFloat64([10.11, 20.22, 30.33]);
+    expect(buffer.length, equals(32));
+
+    buffer.seek(0);
+
+    expect(buffer.readFloat64(), equals(123.456));
+    expect(buffer.position, equals(8));
+
+    expect(buffer.readAllFloat64(3), equals([10.11, 20.22, 30.33]));
+    expect(buffer.position, equals(32));
+  });
+
+  test('writeFloat32/writeAllFloat32', () {
+    var buffer = createBsBuff();
+
+    buffer.writeFloat32(123.456);
+    expect(buffer.length, equals(4));
+
+    buffer.writeAllFloat32([10.11, 20.22, 30.33]);
+    expect(buffer.length, equals(16));
+
+    buffer.seek(0);
+
+    expect(buffer.readFloat32(), inInclusiveRange(123.456, 123.457));
+
+    expect(buffer.position, equals(4));
+
+    var fs = buffer.readAllFloat32(3);
+    expect(fs.length, equals(3));
+    expect(fs[0], inInclusiveRange(10.09, 10.12));
+    expect(fs[1], inInclusiveRange(20.21, 20.23));
+    expect(fs[2], inInclusiveRange(30.32, 30.34));
+    expect(buffer.position, equals(16));
+  });
 }

--- a/test/data_serializer_bytes_buffer_test_base.dart
+++ b/test/data_serializer_bytes_buffer_test_base.dart
@@ -166,12 +166,12 @@ void doBytesBufferTests(
       buffer2.readTo(buffer);
       expect(buffer.length, equals(lng + remaining2));
 
-      buffer2.seek(0);
+      buffer.seek(0);
 
-      remaining2 = buffer2.remaining;
-      lng = buffer.length;
-      buffer.writeFrom(buffer2);
-      expect(buffer.length, equals(lng + remaining2));
+      var remaining1 = buffer.remaining;
+      var lng2 = buffer2.length;
+      buffer2.writeFrom(buffer);
+      expect(buffer2.length, equals(lng2 + remaining1));
     }
 
     expect(buffer.bytesIO.isClosed, isFalse);

--- a/test/data_serializer_bytes_buffer_test_base.dart
+++ b/test/data_serializer_bytes_buffer_test_base.dart
@@ -165,6 +165,13 @@ void doBytesBufferTests(
       var lng = buffer.length;
       buffer2.readTo(buffer);
       expect(buffer.length, equals(lng + remaining2));
+
+      buffer2.seek(0);
+
+      remaining2 = buffer2.remaining;
+      lng = buffer.length;
+      buffer.writeFrom(buffer2);
+      expect(buffer.length, equals(lng + remaining2));
     }
 
     expect(buffer.bytesIO.isClosed, isFalse);

--- a/test/data_serializer_bytes_buffer_test_base.dart
+++ b/test/data_serializer_bytes_buffer_test_base.dart
@@ -1,5 +1,5 @@
-import 'dart:typed_data';
 import 'dart:math' as math;
+import 'dart:typed_data';
 
 import 'package:data_serializer/data_serializer.dart';
 import 'package:test/test.dart';
@@ -112,6 +112,26 @@ void doBytesBufferTests(
     expect(time2, equals(time));
     expect(time2.millisecondsSinceEpoch, equals(timeMs));
     expect(buffer2.position, equals(16));
+
+    {
+      var lengthHalf = buffer.length ~/ 2;
+      var remaining = buffer.length - lengthHalf;
+      buffer.seek(lengthHalf);
+      expect(buffer.remaining, equals(remaining));
+
+      var buffer2Lng = buffer2.length;
+
+      var r = buffer.readTo(buffer2);
+      expect(r, equals(remaining));
+      expect(buffer2.length, equals(buffer2Lng + remaining));
+
+      var w0 = buffer.writeFrom(buffer2);
+      expect(w0, equals(0));
+
+      buffer2.seek(buffer2.length - 2);
+      var w2 = buffer.writeFrom(buffer2);
+      expect(w2, equals(2));
+    }
 
     expect(buffer.bytesIO.isClosed, isFalse);
     expect(buffer2.bytesIO.isClosed, isFalse);

--- a/test/data_serializer_bytes_buffer_test_base.dart
+++ b/test/data_serializer_bytes_buffer_test_base.dart
@@ -155,6 +155,16 @@ void doBytesBufferTests(
       buffer2.seek(buffer2.length - 2);
       var w2 = buffer.writeFrom(buffer2);
       expect(w2, equals(2));
+
+      buffer2.seek(0);
+
+      print(buffer);
+      print(buffer2);
+
+      var remaining2 = buffer2.remaining;
+      var lng = buffer.length;
+      buffer2.readTo(buffer);
+      expect(buffer.length, equals(lng + remaining2));
     }
 
     expect(buffer.bytesIO.isClosed, isFalse);

--- a/test/data_serializer_bytes_buffer_test_base.dart
+++ b/test/data_serializer_bytes_buffer_test_base.dart
@@ -521,6 +521,45 @@ void doBytesBufferTests(
 
     expect(buffer.readAllFloat64(3), equals([10.11, 20.22, 30.33]));
     expect(buffer.position, equals(32));
+
+    var bs = buffer.toBytes();
+    print(bs);
+    expect(
+        bs,
+        equals([
+          64,
+          94,
+          221,
+          47,
+          26,
+          159,
+          190,
+          119,
+          64,
+          36,
+          56,
+          81,
+          235,
+          133,
+          30,
+          184,
+          64,
+          52,
+          56,
+          81,
+          235,
+          133,
+          30,
+          184,
+          64,
+          62,
+          84,
+          122,
+          225,
+          71,
+          174,
+          20
+        ]));
   });
 
   test('writeFloat32/writeAllFloat32', () {
@@ -544,5 +583,28 @@ void doBytesBufferTests(
     expect(fs[1], inInclusiveRange(20.21, 20.23));
     expect(fs[2], inInclusiveRange(30.32, 30.34));
     expect(buffer.position, equals(16));
+
+    var bs = buffer.toBytes();
+    print(bs);
+    expect(
+        bs,
+        equals([
+          66,
+          246,
+          233,
+          121,
+          65,
+          33,
+          194,
+          143,
+          65,
+          161,
+          194,
+          143,
+          65,
+          242,
+          163,
+          215
+        ]));
   });
 }

--- a/test/data_serializer_bytes_buffer_test_base.dart
+++ b/test/data_serializer_bytes_buffer_test_base.dart
@@ -114,10 +114,34 @@ void doBytesBufferTests(
     expect(buffer2.position, equals(16));
 
     {
-      var lengthHalf = buffer.length ~/ 2;
-      var remaining = buffer.length - lengthHalf;
+      final lengthHalf = buffer.length ~/ 2;
+      final remaining = buffer.length - lengthHalf;
+
       buffer.seek(lengthHalf);
       expect(buffer.remaining, equals(remaining));
+
+      var buffer2Lng = buffer2.length;
+
+      var r = buffer.readTo(buffer2);
+      expect(r, equals(remaining));
+      expect(buffer2.length, equals(buffer2Lng + remaining));
+
+      var w0 = buffer.writeFrom(buffer2);
+      expect(w0, equals(0));
+
+      buffer2.seek(buffer2.length - 2);
+      var w2 = buffer.writeFrom(buffer2);
+      expect(w2, equals(2));
+    }
+
+    {
+      final lengthHalf = buffer.length ~/ 2;
+      final remaining = buffer.length - lengthHalf;
+
+      buffer.seek(lengthHalf);
+      expect(buffer.remaining, equals(remaining));
+
+      var buffer2 = BytesBuffer();
 
       var buffer2Lng = buffer2.length;
 

--- a/test/data_serializer_leb128_test.dart
+++ b/test/data_serializer_leb128_test.dart
@@ -58,6 +58,36 @@ void main() {
           expect(Leb128.decodeSigned(bs3), equals(n3));
         }
       }
+
+      for (var n = -1000000; n <= 1000000; n += 11) {
+        for (var i = -3; i <= 3; ++i) {
+          var n3 = n + i;
+
+          var bs3 = Leb128.encodeSigned(n3);
+          expect(Leb128.decodeSigned(bs3), equals(n3));
+        }
+      }
+
+      for (var n = -10000000; n <= 10000000; n += 211) {
+        for (var i = -3; i <= 3; ++i) {
+          var n3 = n + i;
+
+          var bs3 = Leb128.encodeSigned(n3);
+          expect(Leb128.decodeSigned(bs3), equals(n3));
+        }
+      }
+
+      var max = (1 << 36);
+      var min = -max;
+
+      for (var n = min; n <= max; n += 999983) {
+        for (var i = -3; i <= 3; ++i) {
+          var n3 = n + i;
+
+          var bs3 = Leb128.encodeSigned(n3);
+          expect(Leb128.decodeSigned(bs3), equals(n3));
+        }
+      }
     });
 
     test('encodeUnsigned/decodeUnsigned', () {
@@ -227,6 +257,41 @@ void main() {
       expect(bs.readLeb128Block(), equals([1, 2, 3, 4, 5, 6, 7, 8, 9, 0]));
 
       expect(bs.readLeb128Block(), equals([10, 20, 30]));
+    });
+
+    test('basic 4', () {
+      var bs = BytesBuffer();
+
+      {
+        var blk = BytesBuffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 0].asUint8List);
+        bs.writeLeb128BlockFrom(blk);
+      }
+
+      {
+        var blk = BytesBuffer.from([10, 20, 30].asUint8List);
+        bs.writeLeb128BlockFrom(blk);
+      }
+
+      expect(bs.length, equals(1 + 10 + 1 + 3));
+
+      expect(bs.toBytes(),
+          equals([10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 3, 10, 20, 30]));
+
+      bs.seek(0);
+
+      {
+        var blk = BytesBuffer();
+        bs.readLeb128BlockTo(blk);
+
+        expect(blk.toBytes(), equals([1, 2, 3, 4, 5, 6, 7, 8, 9, 0]));
+      }
+
+      {
+        var blk = BytesBuffer();
+        bs.readLeb128BlockTo(blk);
+
+        expect(blk.toBytes(), equals([10, 20, 30]));
+      }
     });
   });
 }

--- a/test/data_serializer_leb128_test.dart
+++ b/test/data_serializer_leb128_test.dart
@@ -210,5 +210,23 @@ void main() {
 
       expect(bs.readLeb128String(), equals("Foooooooooooooooooooooooooooooo"));
     });
+
+    test('basic 3', () {
+      var bs = BytesBuffer();
+
+      bs.writeLeb128Block([1, 2, 3, 4, 5, 6, 7, 8, 9, 0]);
+      bs.writeLeb128Block([10, 20, 30]);
+
+      expect(bs.length, equals(1 + 10 + 1 + 3));
+
+      expect(bs.toBytes(),
+          equals([10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 3, 10, 20, 30]));
+
+      bs.seek(0);
+
+      expect(bs.readLeb128Block(), equals([1, 2, 3, 4, 5, 6, 7, 8, 9, 0]));
+
+      expect(bs.readLeb128Block(), equals([10, 20, 30]));
+    });
   });
 }

--- a/test/data_serializer_writable_test.dart
+++ b/test/data_serializer_writable_test.dart
@@ -53,7 +53,7 @@ void main() {
       expect(o1.serializeBufferLength, greaterThan(8));
     });
 
-    test('writeWritable/readWritable', () {
+    test('writeWritable/readWritable 1', () {
       var buffer = BytesBuffer();
 
       buffer.writeWritable(FooWritable(101, 'FOO'));
@@ -74,6 +74,43 @@ void main() {
 
       var list =
           buffer.readWritables((input) => FooWritable.deserialize(input));
+
+      expect(list.length, equals(3));
+
+      expect(list[0], equals(FooWritable(10, 'Foo')));
+      expect(list[1], equals(FooWritable(11, 'Bar')));
+      expect(list[2], equals(FooWritable(12, 'Baz')));
+
+      var list2 =
+          buffer.readWritables((input) => FooWritable.deserialize(input));
+
+      expect(list2.length, equals(2));
+
+      expect(list2[0], equals(FooWritable(11, 'Bar1')));
+      expect(list2[1], equals(FooWritable(12, 'Baz2')));
+    });
+
+    test('writeWritable/readWritable 2', () {
+      var buffer = BytesBuffer();
+
+      buffer.writeWritable(FooWritable(101, 'FOO'));
+
+      buffer.writeWritables([
+        FooWritable(10, 'Foo'),
+        FooWritable(11, 'Bar'),
+        FooWritable(12, 'Baz'),
+      ], leb128: true);
+
+      [FooWritable(11, 'Bar1'), FooWritable(12, 'Baz2')].writeTo(buffer);
+
+      buffer.seek(0);
+
+      var o = buffer.readWritable((input) => FooWritable.deserialize(input));
+
+      expect(o, equals(FooWritable(101, 'FOO')));
+
+      var list = buffer.readWritables((input) => FooWritable.deserialize(input),
+          leb128: true);
 
       expect(list.length, equals(3));
 


### PR DESCRIPTION
- New `BitsBuffer`.
- `BytesBuffer`:
  - `writeWritables/readWritables`: new parameter option `leb128`.
  - Added `writeFloat64`, `writeAllFloat64`, `readFloat64` and `readAllFloat64`.
  - Added `writeFloat32`, `writeAllFloat32`, `readFloat32` and `readAllFloat32`.
  - Added `readTo` and `writeFrom`.

- test: ^1.24.8