### PR TITLE
v1.1.0 - Dart 3.3.0 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+## 1.1.0
+
+Dart `3.3.0` compatibility changes:
+
+- `ListGenericExtension`:
+  - Renamed getter `asUnmodifiableView` to method `asUnmodifiableListView`.
+
+- `Uint8ListDataExtension`:
+  - Removed getter `asUnmodifiableView` to allow use of `Uint8List.asUnmodifiableView`.
+- `Uint32ListDataExtension`:
+  - Removed getter `asUnmodifiableView` to allow use of `Uint32List.asUnmodifiableView`.
+- `Uint64ListDataExtension`:
+  - Removed getter `asUnmodifiableView` to allow use of `Uint64List.asUnmodifiableView`.
+
+- sdk: '>=3.3.0 <4.0.0'
+
+- lints: ^3.0.0
+- test: ^1.25.2
+- coverage: ^1.7.2
+- path: ^1.9.0
+
 ## 1.0.12
 
 - New `BitsBuffer`.

--- a/lib/src/extension.dart
+++ b/lib/src/extension.dart
@@ -439,7 +439,7 @@ extension ListGenericExtension<T> on List<T> {
   /// Returns an unmodifiable view of `this` instance.
   ///
   /// - Will just cast if is already an [UnmodifiableListView].
-  UnmodifiableListView<T> get asUnmodifiableView {
+  UnmodifiableListView<T> asUnmodifiableListView() {
     var self = this;
     return self is UnmodifiableListView<T>
         ? self
@@ -526,16 +526,6 @@ extension Uint8ListDataExtension on Uint8List {
 
   /// Returns an unmodifiable copy of `this` instance.
   Uint8List copyAsUnmodifiable() => UnmodifiableUint8ListView(copy());
-
-  /// Returns an unmodifiable view of `this` instance.
-  ///
-  /// - Will just cast if is already an [UnmodifiableUint8ListView].
-  UnmodifiableUint8ListView get asUnmodifiableView {
-    var self = this;
-    return self is UnmodifiableUint8ListView
-        ? self
-        : UnmodifiableUint8ListView(self);
-  }
 
   /// Decodes `this` bytes as a `LATIN-1` [String].
   String toStringLatin1() => dart_convert.latin1.decode(this);
@@ -880,16 +870,6 @@ extension Uint32ListDataExtension on Uint32List {
   /// Returns an unmodifiable copy of `this` instance.
   Uint32List copyAsUnmodifiable() => UnmodifiableUint32ListView(copy());
 
-  /// Returns an unmodifiable view of `this` instance.
-  ///
-  /// - Will just cast if is already an [UnmodifiableUint32ListView].
-  UnmodifiableUint32ListView get asUnmodifiableView {
-    var self = this;
-    return self is UnmodifiableUint32ListView
-        ? self
-        : UnmodifiableUint32ListView(self);
-  }
-
   /// Converts this instance to an [Uint8List] with elements in [endian]ness.
   Uint8List convertToUint8List([Endian endian = Endian.big]) {
     if (Endian.host == endian) {
@@ -963,16 +943,6 @@ extension Uint64ListDataExtension on Uint64List {
 
   /// Returns an unmodifiable copy of `this` instance.
   Uint64List copyAsUnmodifiable() => UnmodifiableUint64ListView(copy());
-
-  /// Returns an unmodifiable view of `this` instance.
-  ///
-  /// - Will just cast if is already an [UnmodifiableUint64ListView].
-  UnmodifiableUint64ListView get asUnmodifiableView {
-    var self = this;
-    return self is UnmodifiableUint64ListView
-        ? self
-        : UnmodifiableUint64ListView(self);
-  }
 
   /// Converts this instance to an [Uint8List] with elements in [endian]ness.
   Uint8List convertToUint8List([Endian endian = Endian.big]) {

--- a/lib/src/platform_generic.dart
+++ b/lib/src/platform_generic.dart
@@ -12,10 +12,10 @@ class DataSerializerPlatformGeneric extends DataSerializerPlatform {
   static final int _minSafeInt = -9007199254740991;
 
   static final Uint8List _maxSafeIntBytes =
-      '001FFFFFFFFFFFFF'.decodeHex().asUnmodifiableView;
+      '001FFFFFFFFFFFFF'.decodeHex().asUnmodifiableView();
 
   static final Uint8List _minSafeIntBytes =
-      'FFE0000000000001'.decodeHex().asUnmodifiableView;
+      'FFE0000000000001'.decodeHex().asUnmodifiableView();
 
   @override
   int get maxSafeInt => _maxSafeInt;

--- a/lib/src/platform_io.dart
+++ b/lib/src/platform_io.dart
@@ -12,10 +12,10 @@ class DataSerializerPlatformIO extends DataSerializerPlatform {
   static final int _minSafeInt = -9223372036854775808;
 
   static final Uint8List _maxSafeIntBytes =
-      _maxSafeInt.toUint8List64().asUnmodifiableView;
+      _maxSafeInt.toUint8List64().asUnmodifiableView();
 
   static final Uint8List _minSafeIntBytes =
-      _minSafeInt.toUint8List64().asUnmodifiableView;
+      _minSafeInt.toUint8List64().asUnmodifiableView();
 
   @override
   int get maxSafeInt => _maxSafeInt;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,18 +1,18 @@
 name: data_serializer
 description: Portable Dart package to handle data serialization/deserialization efficiently, including a dynamic BytesBuffer to read/write data.
-version: 1.0.12
+version: 1.1.0
 homepage: https://github.com/gmpassos/data_serializer
 
 environment:
-  sdk: '>=2.18.4 <4.0.0'
+  sdk: '>=3.3.0 <4.0.0'
 
 dependencies:
   base_codecs: ^1.0.1
   collection: ^1.18.0
 
 dev_dependencies:
-  lints: ^2.0.1
-  test: ^1.24.8
+  lints: ^3.0.0
+  test: ^1.25.2
   dependency_validator: ^3.2.3
-  coverage: ^1.6.3
-  path: ^1.8.3
+  coverage: ^1.7.2
+  path: ^1.9.0

--- a/test/data_serializer_extension_64bits_test.dart
+++ b/test/data_serializer_extension_64bits_test.dart
@@ -67,7 +67,7 @@ void main() {
               isA<UnmodifiableUint64ListView>()));
 
       expect(
-          ns64.asUnmodifiableView,
+          ns64.asUnmodifiableView(),
           allOf(equals([0x02030405060708, 0x03040506070809]),
               isA<UnmodifiableUint64ListView>()));
 

--- a/test/data_serializer_extension_num_test.dart
+++ b/test/data_serializer_extension_num_test.dart
@@ -197,7 +197,7 @@ void main() {
       expect(() => Uint8List.fromList([1, 2, 3]).copyAsUnmodifiable()..[0] = 10,
           throwsA(isA<Error>()));
 
-      expect(() => Uint8List.fromList([1, 2, 3]).asUnmodifiableView..[0] = 10,
+      expect(() => Uint8List.fromList([1, 2, 3]).asUnmodifiableView()..[0] = 10,
           throwsA(isA<Error>()));
 
       expect(Uint8List.fromList([1, 10, 20, 30]).bytesHashCode(),

--- a/test/data_serializer_extension_test.dart
+++ b/test/data_serializer_extension_test.dart
@@ -27,10 +27,10 @@ void main() {
 
       expect(l1.reversedList(), equals([8, 7, 6, 5, 4, 3, 2, 1]));
 
-      expect(l1.asUnmodifiableView,
+      expect(l1.asUnmodifiableListView(),
           allOf(equals([1, 2, 3, 4, 5, 6, 7, 8]), isA<UnmodifiableListView>()));
 
-      expect(l1.asUnmodifiableView.asUnmodifiableView,
+      expect(l1.asUnmodifiableListView().asUnmodifiableListView(),
           allOf(equals([1, 2, 3, 4, 5, 6, 7, 8]), isA<UnmodifiableListView>()));
 
       l2.copyTo(2, l1, 2, 3);
@@ -150,7 +150,7 @@ void main() {
               equals([0x01020304, 0x05060708])));
 
       expect(
-          ns32.asUnmodifiableView,
+          ns32.asUnmodifiableView(),
           allOf(isA<UnmodifiableUint32ListView>(),
               equals([0x01020304, 0x05060708])));
 


### PR DESCRIPTION
Dart `3.3.0` compatibility changes:

- `ListGenericExtension`:
  - Renamed getter `asUnmodifiableView` to method `asUnmodifiableListView`.

- `Uint8ListDataExtension`:
  - Removed getter `asUnmodifiableView` to allow use of `Uint8List.asUnmodifiableView`.
- `Uint32ListDataExtension`:
  - Removed getter `asUnmodifiableView` to allow use of `Uint32List.asUnmodifiableView`.
- `Uint64ListDataExtension`:
  - Removed getter `asUnmodifiableView` to allow use of `Uint64List.asUnmodifiableView`.

- sdk: '>=3.3.0 <4.0.0'

- lints: ^3.0.0
- test: ^1.25.2
- coverage: ^1.7.2
- path: ^1.9.0